### PR TITLE
J2ObjC Name Support

### DIFF
--- a/Interop/Indexer/src/main/kotlin/org/jetbrains/kotlin/native/interop/indexer/J2ObjCParser.kt
+++ b/Interop/Indexer/src/main/kotlin/org/jetbrains/kotlin/native/interop/indexer/J2ObjCParser.kt
@@ -45,7 +45,7 @@ class J2ObjCParser: ClassVisitor(Opcodes.ASM5) {
    */
   fun buildClass(): ObjCClass {
     val methods = (methodDescriptors zip parameterNames).map { buildClassMethod(it.first.first, it.first.second, it.first.third, it.second)}
-    val packageClassName = className.split('/').reduce{ acc, string -> acc.capitalize() + string}
+    val packageClassName = buildJ2objcClassName()
 
     val generatedClass = ObjCClassImpl(
       name = packageClassName,
@@ -58,7 +58,7 @@ class J2ObjCParser: ClassVisitor(Opcodes.ASM5) {
       name = "NSObject",
       binaryName = null,
       isForwardDeclaration = false,
-      location = Location(headerId = HeaderId("usr/include/objc/NSObject.h"))
+      location = Location(headerId = HeaderId("usr/include/objc/NSObject.h")) // TODO: When implementing inheritance check for proper base class
     )
     return generatedClass
   }
@@ -101,7 +101,7 @@ class J2ObjCParser: ClassVisitor(Opcodes.ASM5) {
         isOptional = false,
         isInit = false,
         isExplicitlyDesignatedInitializer = false,
-        j2objcNameOverride = true)
+        nameOverride = selector.split("With").first())
     }
   }
 
@@ -112,15 +112,18 @@ class J2ObjCParser: ClassVisitor(Opcodes.ASM5) {
     if (types.size > 0) {
       outputMethodName.append("With" + types.get(0).className.capitalize() + ":")
     }
-    if (types.size > 1) {
-      for (i in 1 until types.size) {
-        outputMethodName.append("with" + types.get(i).className.capitalize() + ":")
-      }
+
+    for (i in 1 until types.size) {
+      outputMethodName.append("with" + types.get(i).className.capitalize() + ":")
     }
+
 
     return outputMethodName.toString()
   }
 
+  private fun buildJ2objcClassName(): String {
+    return className.split('/').reduce{ acc, string -> acc.capitalize() + string}
+  }
 
   /**
    * Parses an ASM method's parameters and returns a list of Kotlin parameters

--- a/Interop/Indexer/src/main/kotlin/org/jetbrains/kotlin/native/interop/indexer/J2ObjCParser.kt
+++ b/Interop/Indexer/src/main/kotlin/org/jetbrains/kotlin/native/interop/indexer/J2ObjCParser.kt
@@ -107,16 +107,12 @@ class J2ObjCParser: ClassVisitor(Opcodes.ASM5) {
 
   private fun buildJ2objcMethodName(methodName: String, methodDesc: String): String {
     val outputMethodName = StringBuilder(methodName)
-
     val types = getArgumentTypes(methodDesc)
+
     if (types.size > 0) {
       outputMethodName.append("With" + types.get(0).className.capitalize() + ":")
     }
-
-    for (i in 1 until types.size) {
-      outputMethodName.append("with" + types.get(i).className.capitalize() + ":")
-    }
-
+    types.drop(1).forEach{outputMethodName.append("with" + it.className.capitalize() + ":")}
 
     return outputMethodName.toString()
   }

--- a/Interop/Indexer/src/main/kotlin/org/jetbrains/kotlin/native/interop/indexer/J2ObjCParser.kt
+++ b/Interop/Indexer/src/main/kotlin/org/jetbrains/kotlin/native/interop/indexer/J2ObjCParser.kt
@@ -72,7 +72,6 @@ class J2ObjCParser: ClassVisitor(Opcodes.ASM5) {
    * @param paramNames List of parameter names of this method taken from MethodBuilder
    */
   private fun buildClassMethod(methodName: String, methodDesc: String, access: Int, paramNames: List<String>): ObjCMethod {
-    buildJ2objcMethodName(methodName, methodDesc)
     if (methodName == "<init>") {
       return ObjCMethod(
         selector = "init",

--- a/Interop/Indexer/src/main/kotlin/org/jetbrains/kotlin/native/interop/indexer/J2ObjCParser.kt
+++ b/Interop/Indexer/src/main/kotlin/org/jetbrains/kotlin/native/interop/indexer/J2ObjCParser.kt
@@ -47,11 +47,6 @@ class J2ObjCParser: ClassVisitor(Opcodes.ASM5) {
     val methods = (methodDescriptors zip parameterNames).map { buildClassMethod(it.first.first, it.first.second, it.first.third, it.second)}
     val packageClassName = className.split('/').reduce{ acc, string -> acc.capitalize() + string}
 
-    println("====")
-    println(className)
-    println(methodDescriptors)
-    println(parameterNames)
-    println("====")
     val generatedClass = ObjCClassImpl(
       name = packageClassName,
       isForwardDeclaration = false,
@@ -63,7 +58,7 @@ class J2ObjCParser: ClassVisitor(Opcodes.ASM5) {
       name = "NSObject",
       binaryName = null,
       isForwardDeclaration = false,
-      location = Location(headerId = HeaderId("usr/include/objc/NSObject.h")) // TODO: When implementing inheritance check for proper base class
+      location = Location(headerId = HeaderId("usr/include/objc/NSObject.h"))
     )
     return generatedClass
   }
@@ -92,11 +87,11 @@ class J2ObjCParser: ClassVisitor(Opcodes.ASM5) {
         isInit = true,
         isExplicitlyDesignatedInitializer = false)
     } else {
-      val selector = StringBuilder(buildJ2objcMethodName(methodName, methodDesc))
+      val selector = buildJ2objcMethodName(methodName, methodDesc)
       val methodParameters = parseMethodParameters(methodDesc, paramNames)
       val methodReturnType = parseMethodReturnType(methodDesc)
       return ObjCMethod(
-        selector = selector.toString(),
+        selector = selector,
         encoding = "[]", //TODO: Implement encoding properly
         parameters = methodParameters,
         returnType = methodReturnType,

--- a/Interop/Indexer/src/main/kotlin/org/jetbrains/kotlin/native/interop/indexer/NativeIndex.kt
+++ b/Interop/Indexer/src/main/kotlin/org/jetbrains/kotlin/native/interop/indexer/NativeIndex.kt
@@ -227,7 +227,7 @@ data class ObjCMethod(
         val selector: String, val encoding: String, val parameters: List<Parameter>, private val returnType: Type,
         val isVariadic: Boolean, val isClass: Boolean, val nsConsumesSelf: Boolean, val nsReturnsRetained: Boolean,
         val isOptional: Boolean, val isInit: Boolean, val isExplicitlyDesignatedInitializer: Boolean,
-        val j2objcNameOverride: Boolean = false
+        val nameOverride: String? = null
 ) {
 
     fun returnsInstancetype(): Boolean = returnType is ObjCInstanceType

--- a/Interop/Indexer/src/main/kotlin/org/jetbrains/kotlin/native/interop/indexer/NativeIndex.kt
+++ b/Interop/Indexer/src/main/kotlin/org/jetbrains/kotlin/native/interop/indexer/NativeIndex.kt
@@ -226,7 +226,8 @@ sealed class ObjCClassOrProtocol(val name: String) : ObjCContainer(), TypeDeclar
 data class ObjCMethod(
         val selector: String, val encoding: String, val parameters: List<Parameter>, private val returnType: Type,
         val isVariadic: Boolean, val isClass: Boolean, val nsConsumesSelf: Boolean, val nsReturnsRetained: Boolean,
-        val isOptional: Boolean, val isInit: Boolean, val isExplicitlyDesignatedInitializer: Boolean
+        val isOptional: Boolean, val isInit: Boolean, val isExplicitlyDesignatedInitializer: Boolean,
+        val j2objcNameOverride: Boolean = false
 ) {
 
     fun returnsInstancetype(): Boolean = returnType is ObjCInstanceType

--- a/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/ObjCStubs.kt
+++ b/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/ObjCStubs.kt
@@ -106,7 +106,7 @@ private class ObjCMethodStubBuilder(
     private val kotlinMethodParameters: List<FunctionParameterStub>
     private val external: Boolean
     private val receiver: ReceiverParameterStub?
-    private val name: String = if (method.j2objcNameOverride) method.j2objcName else method.kotlinName
+    private val name: String = method.nameOverride ?: method.kotlinName
     private val origin = StubOrigin.ObjCMethod(method, container)
     private val modality: MemberStubModality
     private val isOverride: Boolean =
@@ -253,11 +253,6 @@ internal val ObjCMethod.kotlinName: String
         } else {
             candidate
         }
-    }
-
-internal val ObjCMethod.j2objcName: String
-    get() {
-        return selector.split("With").first()
     }
 
 internal val ObjCClassOrProtocol.protocolsWithSupers: Sequence<ObjCProtocol>

--- a/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/ObjCStubs.kt
+++ b/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/ObjCStubs.kt
@@ -106,7 +106,7 @@ private class ObjCMethodStubBuilder(
     private val kotlinMethodParameters: List<FunctionParameterStub>
     private val external: Boolean
     private val receiver: ReceiverParameterStub?
-    private val name: String = method.kotlinName
+    private val name: String = if (method.j2objcNameOverride) method.j2objcName else method.kotlinName
     private val origin = StubOrigin.ObjCMethod(method, container)
     private val modality: MemberStubModality
     private val isOverride: Boolean =
@@ -253,6 +253,11 @@ internal val ObjCMethod.kotlinName: String
         } else {
             candidate
         }
+    }
+
+internal val ObjCMethod.j2objcName: String
+    get() {
+        return selector.split("With").first()
     }
 
 internal val ObjCClassOrProtocol.protocolsWithSupers: Sequence<ObjCProtocol>

--- a/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/jvm/main.kt
+++ b/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/jvm/main.kt
@@ -38,12 +38,10 @@ import org.jetbrains.kotlin.library.resolver.impl.KotlinLibraryResolverImpl
 import org.jetbrains.kotlin.library.resolver.impl.libraryResolver
 import org.jetbrains.kotlin.library.toUnresolvedLibraries
 import org.jetbrains.kotlin.util.removeSuffixIfPresent
-import org.jetbrains.org.objectweb.asm.ClassReader
 import java.io.File
 import java.lang.IllegalArgumentException
 import java.nio.file.*
 import java.util.*
-import java.util.jar.JarFile
 
 data class InternalInteropOptions(val generated: String, val natives: String, val manifest: String? = null,
                                   val cstubsName: String? = null)

--- a/Interop/StubGenerator/src/test/kotlin/org/jetbrains/kotlin/native/interop/gen/J2ObjcManglingTest.kt
+++ b/Interop/StubGenerator/src/test/kotlin/org/jetbrains/kotlin/native/interop/gen/J2ObjcManglingTest.kt
@@ -40,10 +40,10 @@ class J2ObjcManglingTest {
   @Test
   fun `kotlin function name generated properly`() {
     val generated = parser.buildClass()
-    assertEquals("foo", generated.methods.get(0).j2objcName)
-    assertEquals("foo", generated.methods.get(1).j2objcName)
-    assertEquals("foo", generated.methods.get(2).j2objcName)
-    assertEquals("foo", generated.methods.get(3).j2objcName)
+    assertEquals("foo", generated.methods.get(0).nameOverride)
+    assertEquals("foo", generated.methods.get(1).nameOverride)
+    assertEquals("foo", generated.methods.get(2).nameOverride)
+    assertEquals("foo", generated.methods.get(3).nameOverride)
   }
 
 }

--- a/Interop/StubGenerator/src/test/kotlin/org/jetbrains/kotlin/native/interop/gen/J2ObjcManglingTest.kt
+++ b/Interop/StubGenerator/src/test/kotlin/org/jetbrains/kotlin/native/interop/gen/J2ObjcManglingTest.kt
@@ -1,0 +1,49 @@
+package org.jetbrains.kotlin.native.interop.gen
+
+import org.jetbrains.kotlin.native.interop.indexer.*
+import org.junit.Before
+import org.junit.Test
+import kotlin.test.assertEquals
+
+
+class J2ObjcManglingTest {
+  private val parser = J2ObjCParser()
+
+  @Before
+  fun setUp() {
+    parser.className = "com/Example/Foo"
+    parser.methodDescriptors.add(Triple("foo","()V",0))
+    parser.methodDescriptors.add(Triple("foo", "(I)V",0))
+    parser.methodDescriptors.add(Triple("foo", "(II)V", 0))
+    parser.methodDescriptors.add(Triple("foo", "(IFZDCJSB)V", 0))
+    parser.parameterNames.add(listOf<String>())
+    parser.parameterNames.add(listOf<String>("a"))
+    parser.parameterNames.add(listOf<String>("a","b"))
+    parser.parameterNames.add(listOf<String>("a","b","c","d","e","f","g","h","i"))
+  }
+
+  @Test
+  fun `package name is added to class name`() {
+    val generated = parser.buildClass()
+    assertEquals("ComExampleFoo", generated.name)
+  }
+
+  @Test
+  fun `j2objc selector generated properly`() {
+    val generated = parser.buildClass()
+    assertEquals("foo", generated.methods.get(0).selector)
+    assertEquals("fooWithInt:", generated.methods.get(1).selector)
+    assertEquals("fooWithInt:withInt:", generated.methods.get(2).selector)
+    assertEquals("fooWithInt:withFloat:withBoolean:withDouble:withChar:withLong:withShort:withByte:", generated.methods.get(3).selector)
+  }
+
+  @Test
+  fun `kotlin function name generated properly`() {
+    val generated = parser.buildClass()
+    assertEquals("foo", generated.methods.get(0).j2objcName)
+    assertEquals("foo", generated.methods.get(1).j2objcName)
+    assertEquals("foo", generated.methods.get(2).j2objcName)
+    assertEquals("foo", generated.methods.get(3).j2objcName)
+  }
+
+}


### PR DESCRIPTION
This PR covers supporting naming the resulting kotlin functions to their original name, and the internal selector names to the generated J2ObjC ObjC names.

add2(int x, int y) -> add2()                                external kotlin name
                             -> add2WithInt:withInt:         ObjC selector after J2ObjC

Currently covers changing methods based on parameters and package names appended to class names. Will maybe have to implement more of these as more features in the project get implemented and mangled by j2objc.